### PR TITLE
allow for sqlite backend database for low-profile self-hosting deploy…

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -392,14 +392,29 @@ func OpenDB() (*gorm.DB, error) {
 		return db, nil
 	}
 
-	postgresDb := fmt.Sprintf(PostgresDb, os.Getenv("POSTGRESQL_PASSWORD"))
-	if os.Getenv("HISHTORY_POSTGRES_DB") != "" {
-		postgresDb = os.Getenv("HISHTORY_POSTGRES_DB")
+	var sqliteDb string
+
+	if os.Getenv("HISHTORY_SQLITE_DB") != "" {
+		sqliteDb = os.Getenv("HISHTORY_SQLITE_DB")
 	}
-	db, err := gorm.Open(postgres.Open(postgresDb), &gorm.Config{})
+
+	var db *gorm.DB
+	var err error
+
+	if sqliteDb != "" {
+		db, err = gorm.Open(sqlite.Open(sqliteDb), &gorm.Config{})
+	} else {
+		postgresDb := fmt.Sprintf(PostgresDb, os.Getenv("POSTGRESQL_PASSWORD"))
+		if os.Getenv("HISHTORY_POSTGRES_DB") != "" {
+			postgresDb = os.Getenv("HISHTORY_POSTGRES_DB")
+		}
+		db, err = gorm.Open(postgres.Open(postgresDb), &gorm.Config{})
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to the DB: %v", err)
 	}
+
 	db.AutoMigrate(&shared.EncHistoryEntry{})
 	db.AutoMigrate(&shared.Device{})
 	db.AutoMigrate(&UsageData{})


### PR DESCRIPTION
…ments

Just a quick proof of concept to validate that the gorm config will work well with sqlite on a low-profile backend self-hosted, in case others don't want the weight of running postgresql for their own history.