### PR TITLE
Allow search strings to escape special chars ' ', ':' and '-' using '\'

### DIFF
--- a/client/lib/lib.go
+++ b/client/lib/lib.go
@@ -1240,20 +1240,21 @@ func tokenize(query string) ([]string, error) {
 	return splitEscaped(query, ' ', -1), nil
 }
 
-func splitEscaped(query string, separator byte, maxSplit int) []string {
-	var token []byte
+func splitEscaped(query string, separator rune, maxSplit int) []string {
+	var token []rune
 	var tokens []string
-	var splits = 1
-	for i := 0; i < len(query); i++ {
-		if (maxSplit < 0 || splits < maxSplit) && query[i] == separator {
+	splits := 1
+	runeQuery := []rune(query)
+	for i := 0; i < len(runeQuery); i++ {
+		if (maxSplit < 0 || splits < maxSplit) && runeQuery[i] == separator {
 			tokens = append(tokens, string(token))
 			token = token[:0]
 			splits++
-		} else if query[i] == '\\' && i+1 < len(query) {
-			token = append(token, query[i], query[i+1])
+		} else if runeQuery[i] == '\\' && i+1 < len(runeQuery) {
+			token = append(token, runeQuery[i], runeQuery[i+1])
 			i++
 		} else {
-			token = append(token, query[i])
+			token = append(token, runeQuery[i])
 		}
 	}
 	tokens = append(tokens, string(token))
@@ -1261,10 +1262,11 @@ func splitEscaped(query string, separator byte, maxSplit int) []string {
 }
 
 func containsUnescaped(query string, token string) bool {
-	for i := 0; i < len(query); i++ {
-		if query[i] == '\\' && i+1 < len(query) {
+	runeQuery := []rune(query)
+	for i := 0; i < len(runeQuery); i++ {
+		if runeQuery[i] == '\\' && i+1 < len(runeQuery) {
 			i++
-		} else if query[i:i+len(token)] == token {
+		} else if string(runeQuery[i:i+len(token)]) == token {
 			return true
 		}
 	}
@@ -1272,12 +1274,13 @@ func containsUnescaped(query string, token string) bool {
 }
 
 func deEscape(query string) string {
-	var newQuery []byte
-	for i := 0; i < len(query); i++ {
-		if query[i] == '\\' && i+1 < len(query) {
+	runeQuery := []rune(query)
+	var newQuery []rune
+	for i := 0; i < len(runeQuery); i++ {
+		if runeQuery[i] == '\\' && i+1 < len(runeQuery) {
 			i++
 		}
-		newQuery = append(newQuery, query[i])
+		newQuery = append(newQuery, runeQuery[i])
 	}
 	return string(newQuery)
 }


### PR DESCRIPTION
Hi.

First thank you for developing this package, really nice to use.

This PR fixes issue https://github.com/ddworken/hishtory/issues/65 , and allows a user to search for strings containing the special characters ' ', '-' & ':' by escaping them with a '\\'.
It would seem running your suite test requires specific items and permissions(?), but this builds and works fine for me in bash on Ubuntu 22.04, and since it only affects internal workings of hishtory there is no reason to believe it wont work on any other platform as well...
Please advise if I have misunderstood something regarding how to run the test suite so that I can fix this PR and do better next time.