### PR TITLE
Filter duplicates with map

### DIFF
--- a/client/lib/lib.go
+++ b/client/lib/lib.go
@@ -157,19 +157,25 @@ func DisplayResults(ctx context.Context, results []*data.HistoryEntry, numResult
 	tbl := table.New(columns...)
 	tbl.WithHeaderFormatter(headerFmt)
 
-	lastCommand := ""
 	numRows := 0
+
+	var seenCommands = make(map[string]bool)
+
 	for _, entry := range results {
-		if entry != nil && strings.TrimSpace(entry.Command) == strings.TrimSpace(lastCommand) && config.FilterDuplicateCommands {
-			continue
+		if config.FilterDuplicateCommands && entry != nil {
+			cmd := strings.TrimSpace(entry.Command)
+			if seenCommands[cmd] {
+				continue
+			}
+			seenCommands[cmd] = true
 		}
+
 		row, err := BuildTableRow(ctx, config.DisplayedColumns, *entry)
 		if err != nil {
 			return err
 		}
 		tbl.AddRow(stringArrayToAnyArray(row)...)
 		numRows += 1
-		lastCommand = entry.Command
 		if numRows >= numResults {
 			break
 		}


### PR DESCRIPTION
The previous method of filtering duplicates only worked on duplicates that occurred consecutively. Since dupes happen out of order often, this switches the logic to instead use a map of seen commands and filter based on that.


I don't know go super well so I couldn't figure out how to test it, but this command will reproduce the issue by printing duplicate command counts:
```
hishtory query "ls" | awk '{$1=$2=""; print $0}' | sort | uniq -c | sort -k1n | tail  
```

Running this with a local build of my branch removes all the duplicates.