### PR TITLE
Allow override of serving port by env var

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -211,7 +211,11 @@ func main() {
 
 	go runBackgroundJobs(context.Background(), srv, db, stats)
 
-	if err := srv.Run(context.Background(), ":8080"); err != nil {
+	port := os.Getenv("HISHTORY_SERVER_PORT")
+	if port == "" {
+		port = "8080"
+	}
+	if err := srv.Run(context.Background(), ":"+port); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Can now set HISHTORY_SERVER_PORT but will default to 8080.

A couple of caveats -
1. this is my first public PR so it's totally possible I've messed it up. 
2. I've barely written any Go and don't have a working Go environment at present so this  might not actually work but I thought it was likely at least more helpful than just raising an issue :)