### PR TITLE
Add new short name for "ExitCode" - "$?"

### DIFF
--- a/client/lib/lib.go
+++ b/client/lib/lib.go
@@ -104,7 +104,7 @@ func BuildTableRow(ctx context.Context, columnNames []string, entry data.History
 			} else {
 				row = append(row, entry.EndTime.Local().Sub(entry.StartTime.Local()).Round(time.Millisecond).String())
 			}
-		case "Exit Code", "Exit_Code", "ExitCode", "exitcode":
+		case "Exit Code", "Exit_Code", "ExitCode", "exitcode", "$?", "EC":
 			row = append(row, fmt.Sprintf("%d", entry.ExitCode))
 		case "Command", "command":
 			row = append(row, commandRenderer(entry.Command))


### PR DESCRIPTION
Hi @ddworken,

Thank you very much for such an awesome project! I used to save history between different machine in git repository which is neither secure, nor convenient. And I additionally thankful for ability to self-host it, even knowing that I don't have to trust the server and everything is encrypted (which is amazing), I still feel better self-hosting it.

Now, about the PR.
I have not so much space in my terminal usually, and want to see as much of the command line as I can. At the same time, it's nice to be able to see other columns as well.

This PR is aimed to save some space making the "Exit Code" column be able to have "$?" or "EC" names.
By default the column takes a lot of space, while all the values are just 1-3 digits, that's why I'd like to request this column to be shorter (maybe even by default, if you'd like to).


