### PR TITLE
Redirect stdout/stderr for fish command in fish configuration scripts

### DIFF
--- a/client/lib/config.fish
+++ b/client/lib/config.fish
@@ -32,3 +32,5 @@ function __hishtory_on_control_r
 end
 
 [ (hishtory config-get enable-control-r) = true ] && bind \cr __hishtory_on_control_r
+
+hishtory completion fish | source

--- a/client/lib/config.fish
+++ b/client/lib/config.fish
@@ -11,12 +11,14 @@ function _hishtory_post_exec --on-event fish_preexec
 end
 
 function __hishtory_on_prompt --on-event fish_postexec
+    # Runs after <ENTER>, after the command is executed
     set _hishtory_exit_code $status
     hishtory saveHistoryEntry fish $_hishtory_exit_code \"$_hishtory_command\" $_hishtory_start_time &> /dev/null &
     builtin disown
     hishtory updateLocalDbFromRemote &> /dev/null &
     builtin disown
-    set --global -e _hishtory_command  # Unset _hishtory_command so we don't double-save entries when fish_prompt is invoked but fish_postexec isn't
+    # Unset _hishtory_command so we don't double-save entries when fish_prompt is invoked but fish_postexec isn't
+    set --global -e _hishtory_command
 end
 
 function __hishtory_on_control_r

--- a/client/lib/config.fish
+++ b/client/lib/config.fish
@@ -32,5 +32,3 @@ function __hishtory_on_control_r
 end
 
 [ (hishtory config-get enable-control-r) = true ] && bind \cr __hishtory_on_control_r
-
-hishtory completion fish | source

--- a/client/lib/config.fish
+++ b/client/lib/config.fish
@@ -6,36 +6,29 @@ function _hishtory_post_exec --on-event fish_preexec
     # Runs after <ENTER>, but before the command is executed
     set --global _hishtory_command $argv
     set --global _hishtory_start_time (hishtory getTimestamp)
-    hishtory presaveHistoryEntry fish "$_hishtory_command" $_hishtory_start_time &; disown # Background Run
-    # hishtory presaveHistoryEntry fish "$_hishtory_command" $_hishtory_start_time # Foreground Run
+    hishtory presaveHistoryEntry fish "$_hishtory_command" $_hishtory_start_time &> /dev/null &
+    builtin disown
 end
 
-set --global _hishtory_first_prompt 1
-
-function __hishtory_on_prompt --on-event fish_prompt
-    # Runs after the command is executed in order to render the prompt
-    # $? contains the exit code 
+function __hishtory_on_prompt --on-event fish_postexec
     set _hishtory_exit_code $status
-    if [ -n "$_hishtory_first_prompt" ]
-        set --global -e _hishtory_first_prompt
-    else if [ -n "$_hishtory_command" ]
-        hishtory saveHistoryEntry fish $_hishtory_exit_code "$_hishtory_command" $_hishtory_start_time &; disown  # Background Run
-        # hishtory saveHistoryEntry fish $_hishtory_exit_code "$_hishtory_command" $_hishtory_start_time  # Foreground Run
-        hishtory updateLocalDbFromRemote &; disown
-        set --global -e _hishtory_command  # Unset _hishtory_command so we don't double-save entries when fish_prompt is invoked but fish_postexec isn't
-    end 
+    hishtory saveHistoryEntry fish $_hishtory_exit_code \"$_hishtory_command\" $_hishtory_start_time &> /dev/null &
+    builtin disown
+    hishtory updateLocalDbFromRemote &> /dev/null &
+    builtin disown
+    set --global -e _hishtory_command  # Unset _hishtory_command so we don't double-save entries when fish_prompt is invoked but fish_postexec isn't
 end
 
 function __hishtory_on_control_r
-	set -l tmp (mktemp -t fish.XXXXXX)
-	set -x init_query (commandline -b)
-	HISHTORY_TERM_INTEGRATION=1 HISHTORY_SHELL_NAME=fish hishtory tquery $init_query > $tmp
-	set -l res $status
-	commandline -f repaint
-	if [ -s $tmp ]
-		commandline -r -- (cat $tmp)
-	end
-	rm -f $tmp
+    set -l tmp (mktemp -t fish.XXXXXX)
+    set -x init_query (commandline -b)
+    HISHTORY_TERM_INTEGRATION=1 HISHTORY_SHELL_NAME=fish hishtory tquery $init_query > $tmp
+    set -l res $status
+    commandline -f repaint
+    if [ -s $tmp ]
+        commandline -r -- (cat $tmp)
+    end
+    rm -f $tmp
 end
 
 [ (hishtory config-get enable-control-r) = true ] && bind \cr __hishtory_on_control_r

--- a/client/lib/config.fish
+++ b/client/lib/config.fish
@@ -13,7 +13,7 @@ end
 function __hishtory_on_prompt --on-event fish_postexec
     # Runs after <ENTER>, after the command is executed
     set _hishtory_exit_code $status
-    hishtory saveHistoryEntry fish $_hishtory_exit_code \"$_hishtory_command\" $_hishtory_start_time &> /dev/null &
+    hishtory saveHistoryEntry fish $_hishtory_exit_code "$_hishtory_command" $_hishtory_start_time &> /dev/null &
     builtin disown
     hishtory updateLocalDbFromRemote &> /dev/null &
     builtin disown


### PR DESCRIPTION
I am trying to migrate to `fish` and I found the fish configuration scripts for hishtory is buggy. 
I always get some gabbage escape sequence after sourcing `~/.hishtory/config.fish`
<img width="307" alt="Screenshot 2024-10-14 at 11 27 22 AM" src="https://github.com/user-attachments/assets/313af1ec-21b0-4c94-beca-1bebc17cafca">

Upon investigation, it seems that sometimes `hishtory` print message to stdout/stderr, which confuse `fish`.

In this PR, I
* redirect all the command to `&> /dev/null`
* use `fish_postexec` to simplify code and improve reliability
* cleanup the style