### PR TITLE
Add support to skip modifying shell configs during the hishtory update process, since the shell configs are already set up at that point and haven't ever needed to change

### DIFF
--- a/client/cmd/install.go
+++ b/client/cmd/install.go
@@ -26,10 +26,11 @@ import (
 )
 
 var (
-	offlineInit            *bool
-	forceInit              *bool
-	offlineInstall         *bool
-	skipConfigModification *bool
+	offlineInit                  *bool
+	forceInit                    *bool
+	offlineInstall               *bool
+	skipConfigModification       *bool
+	skipUpdateConfigModification *bool
 )
 
 var installCmd = &cobra.Command{
@@ -45,7 +46,7 @@ var installCmd = &cobra.Command{
 		if strings.HasPrefix(secretKey, "-") {
 			lib.CheckFatalError(fmt.Errorf("secret key %#v looks like a CLI flag, please use a secret key that does not start with a -", secretKey))
 		}
-		lib.CheckFatalError(install(secretKey, *offlineInstall, *skipConfigModification))
+		lib.CheckFatalError(install(secretKey, *offlineInstall, *skipConfigModification || *skipUpdateConfigModification))
 		if os.Getenv("HISHTORY_SKIP_INIT_IMPORT") == "" {
 			db, err := hctx.OpenLocalSqliteDb()
 			lib.CheckFatalError(err)
@@ -686,4 +687,5 @@ func init() {
 	forceInit = initCmd.Flags().Bool("force", false, "Force re-init without any prompts")
 	offlineInstall = installCmd.Flags().Bool("offline", false, "Install hiSHtory in offline mode with all syncing capabilities disabled")
 	skipConfigModification = installCmd.Flags().Bool("skip-config-modification", false, "Skip modifying shell configs and instead instruct the user on how to modify their configs")
+	skipUpdateConfigModification = installCmd.Flags().Bool("skip-update-config-modification", false, "Skip modifying shell configs for updates")
 }

--- a/client/cmd/install.go
+++ b/client/cmd/install.go
@@ -31,6 +31,9 @@ var (
 	offlineInstall               *bool
 	skipConfigModification       *bool
 	skipUpdateConfigModification *bool
+
+	//lint:ignore U1000 Flag that is allowed to be specified, but not used
+	currentlyInstalledVersion *string
 )
 
 var installCmd = &cobra.Command{
@@ -688,4 +691,5 @@ func init() {
 	offlineInstall = installCmd.Flags().Bool("offline", false, "Install hiSHtory in offline mode with all syncing capabilities disabled")
 	skipConfigModification = installCmd.Flags().Bool("skip-config-modification", false, "Skip modifying shell configs and instead instruct the user on how to modify their configs")
 	skipUpdateConfigModification = installCmd.Flags().Bool("skip-update-config-modification", false, "Skip modifying shell configs for updates")
+	currentlyInstalledVersion = installCmd.Flags().String("currently-installed-version", "", "The currently installed version (used by the update command)")
 }

--- a/client/cmd/update.go
+++ b/client/cmd/update.go
@@ -112,7 +112,7 @@ func update(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to chmod +x the update (stdout=%#v, stderr=%#v): %w", stdout.String(), stderr.String(), err)
 	}
-	cmd = exec.Command(getTmpClientPath(), "install", "--skip-update-config-modification")
+	cmd = exec.Command(getTmpClientPath(), "install")
 	cmd.Stdout = os.Stdout
 	stderr = bytes.Buffer{}
 	cmd.Stdin = os.Stdin

--- a/client/cmd/update.go
+++ b/client/cmd/update.go
@@ -112,7 +112,7 @@ func update(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to chmod +x the update (stdout=%#v, stderr=%#v): %w", stdout.String(), stderr.String(), err)
 	}
-	cmd = exec.Command(getTmpClientPath(), "install")
+	cmd = exec.Command(getTmpClientPath(), "install", "--skip-config-modification")
 	cmd.Stdout = os.Stdout
 	stderr = bytes.Buffer{}
 	cmd.Stdin = os.Stdin

--- a/client/cmd/update.go
+++ b/client/cmd/update.go
@@ -112,7 +112,7 @@ func update(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to chmod +x the update (stdout=%#v, stderr=%#v): %w", stdout.String(), stderr.String(), err)
 	}
-	cmd = exec.Command(getTmpClientPath(), "install", "--skip-config-modification")
+	cmd = exec.Command(getTmpClientPath(), "install", "--skip-update-config-modification")
 	cmd.Stdout = os.Stdout
 	stderr = bytes.Buffer{}
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
Note that this only adds the flag, a separate PR (with a separate release) will actually start setting the flag. 

#257 