### PR TITLE
style: named returns for err-funcs

### DIFF
--- a/backend/server/internal/database/device.go
+++ b/backend/server/internal/database/device.go
@@ -21,8 +21,7 @@ type Device struct {
 	UninstallDate time.Time `json:"uninstall_date"`
 }
 
-func (db *DB) CountAllDevices(ctx context.Context) (int64, error) {
-	var numDevices int64 = 0
+func (db *DB) CountAllDevices(ctx context.Context) (numDevices int64, err error) {
 	tx := db.WithContext(ctx).Model(&Device{}).Count(&numDevices)
 	if tx.Error != nil {
 		return 0, fmt.Errorf("tx.Error: %w", tx.Error)
@@ -31,8 +30,7 @@ func (db *DB) CountAllDevices(ctx context.Context) (int64, error) {
 	return numDevices, nil
 }
 
-func (db *DB) CountDevicesForUser(ctx context.Context, userID string) (int64, error) {
-	var existingDevicesCount int64
+func (db *DB) CountDevicesForUser(ctx context.Context, userID string) (existingDevicesCount int64, err error) {
 	tx := db.WithContext(ctx).Model(&Device{}).Where("user_id = ?", userID).Count(&existingDevicesCount)
 	if tx.Error != nil {
 		return 0, fmt.Errorf("tx.Error: %w", tx.Error)
@@ -41,7 +39,7 @@ func (db *DB) CountDevicesForUser(ctx context.Context, userID string) (int64, er
 	return existingDevicesCount, nil
 }
 
-func (db *DB) CreateDevice(ctx context.Context, device *Device) error {
+func (db *DB) CreateDevice(ctx context.Context, device *Device) (err error) {
 	tx := db.WithContext(ctx).Create(device)
 	if tx.Error != nil {
 		return fmt.Errorf("tx.Error: %w", tx.Error)
@@ -50,12 +48,11 @@ func (db *DB) CreateDevice(ctx context.Context, device *Device) error {
 	return nil
 }
 
-func (db *DB) DevicesForUser(ctx context.Context, userID string) ([]*Device, error) {
-	var devices []*Device
-	tx := db.WithContext(ctx).Where("user_id = ? AND (uninstall_date IS NULL OR uninstall_date < '1971-01-01')", userID).Find(&devices)
+func (db *DB) DevicesForUser(ctx context.Context, userID string) (devicesPtr []*Device, err error) {
+	tx := db.WithContext(ctx).Where("user_id = ? AND (uninstall_date IS NULL OR uninstall_date < '1971-01-01')", userID).Find(&devicesPtr)
 	if tx.Error != nil {
 		return nil, fmt.Errorf("tx.Error: %w", tx.Error)
 	}
 
-	return devices, nil
+	return devicesPtr, nil
 }

--- a/backend/server/internal/release/release.go
+++ b/backend/server/internal/release/release.go
@@ -19,7 +19,7 @@ type releaseInfo struct {
 
 const releaseURL = "https://api.github.com/repos/ddworken/hishtory/releases/latest"
 
-func UpdateReleaseVersion() error {
+func UpdateReleaseVersion() (err error) {
 	resp, err := http.Get(releaseURL)
 	if err != nil {
 		return fmt.Errorf("failed to get latest release version: %w", err)
@@ -85,7 +85,7 @@ func decrementVersionIfInvalid(initialVersion string) string {
 	return initialVersion
 }
 
-func assertValidUpdate(updateInfo shared.UpdateInfo) error {
+func assertValidUpdate(updateInfo shared.UpdateInfo) (err error) {
 	urls := []string{
 		updateInfo.LinuxAmd64Url,
 		updateInfo.LinuxAmd64AttestationUrl,
@@ -114,7 +114,7 @@ func assertValidUpdate(updateInfo shared.UpdateInfo) error {
 	return nil
 }
 
-func decrementVersion(version string) (string, error) {
+func decrementVersion(version string) (parsedVersion string, err error) {
 	if version == "UNKNOWN" {
 		return "", fmt.Errorf("cannot decrement UNKNOWN")
 	}

--- a/backend/server/internal/server/srv.go
+++ b/backend/server/internal/server/srv.go
@@ -75,7 +75,7 @@ func TrackUsageData(v bool) Option {
 	}
 }
 
-func NewServer(db *database.DB, options ...Option) *Server {
+func NewServer(db *database.DB, options ...Option) (serverPtr *Server) {
 	srv := Server{db: db}
 	for _, option := range options {
 		option(&srv)
@@ -86,7 +86,7 @@ func NewServer(db *database.DB, options ...Option) *Server {
 	return &srv
 }
 
-func (s *Server) Run(ctx context.Context, addr string) error {
+func (s *Server) Run(ctx context.Context, addr string) (err error) {
 	mux := httptrace.NewServeMux()
 
 	if s.isProductionEnvironment {
@@ -157,7 +157,7 @@ func (s *Server) handleNonCriticalError(err error) {
 	}
 }
 
-func (s *Server) updateUsageData(ctx context.Context, version, remoteAddr, userId, deviceId string, numEntriesHandled int, isQuery bool) error {
+func (s *Server) updateUsageData(ctx context.Context, version, remoteAddr, userId, deviceId string, numEntriesHandled int, isQuery bool) (err error) {
 	if !s.trackUsageData {
 		return nil
 	}

--- a/client/ai/ai.go
+++ b/client/ai/ai.go
@@ -19,7 +19,7 @@ import (
 
 var mostRecentQuery string
 
-func DebouncedGetAiSuggestions(ctx context.Context, shellName, query string, numberCompletions int) ([]string, error) {
+func DebouncedGetAiSuggestions(ctx context.Context, shellName, query string, numberCompletions int) (suggestions []string, err error) {
 	mostRecentQuery = query
 	time.Sleep(time.Millisecond * 300)
 	if mostRecentQuery == query {
@@ -78,7 +78,7 @@ func augmentQuery(ctx context.Context, query string) string {
 	return newQuery
 }
 
-func GetAiSuggestions(ctx context.Context, shellName, query string, numberCompletions int) ([]string, error) {
+func GetAiSuggestions(ctx context.Context, shellName, query string, numberCompletions int) (suggestions []string, err error) {
 	if os.Getenv("OPENAI_API_KEY") == "" && hctx.GetConf(ctx).AiCompletionEndpoint == ai.DefaultOpenAiEndpoint {
 		return GetAiSuggestionsViaHishtoryApi(ctx, shellName, augmentQuery(ctx, query), numberCompletions)
 	} else {
@@ -107,7 +107,7 @@ func getOsName() string {
 	}
 }
 
-func GetAiSuggestionsViaHishtoryApi(ctx context.Context, shellName, query string, numberCompletions int) ([]string, error) {
+func GetAiSuggestionsViaHishtoryApi(ctx context.Context, shellName, query string, numberCompletions int) (suggestions []string, err error) {
 	hctx.GetLogger().Infof("Running OpenAI query for %#v via hishtory server", query)
 	req := ai.AiSuggestionRequest{
 		DeviceId:          hctx.GetConf(ctx).DeviceId,

--- a/client/cmd/enableDisable.go
+++ b/client/cmd/enableDisable.go
@@ -29,13 +29,13 @@ var disableCmd = &cobra.Command{
 	},
 }
 
-func Enable(ctx context.Context) error {
+func Enable(ctx context.Context) (err error) {
 	config := hctx.GetConf(ctx)
 	config.IsEnabled = true
 	return hctx.SetConfig(config)
 }
 
-func Disable(ctx context.Context) error {
+func Disable(ctx context.Context) (err error) {
 	config := hctx.GetConf(ctx)
 	config.IsEnabled = false
 	return hctx.SetConfig(config)

--- a/client/cmd/export.go
+++ b/client/cmd/export.go
@@ -25,17 +25,16 @@ var exportJsonCmd = &cobra.Command{
 	},
 }
 
-func structToMap(entry data.HistoryEntry) (map[string]interface{}, error) {
+func structToMap(entry data.HistoryEntry) (m map[string]interface{}, err error) {
 	inrec, err := json.Marshal(entry)
 	if err != nil {
 		return nil, err
 	}
-	var m map[string]interface{}
 	err = json.Unmarshal(inrec, &m)
 	return m, err
 }
 
-func exportToJson(ctx context.Context, w io.Writer) error {
+func exportToJson(ctx context.Context, w io.Writer) (err error) {
 	db := hctx.GetDb(ctx)
 	chunkSize := 1000
 	offset := 0

--- a/client/cmd/import.go
+++ b/client/cmd/import.go
@@ -48,7 +48,7 @@ var importJsonCmd = &cobra.Command{
 	},
 }
 
-func importFromJson(ctx context.Context) (int, error) {
+func importFromJson(ctx context.Context) (lenEntries int, err error) {
 	// Get the data needed for filling in any missing columns
 	currentUser, err := user.Current()
 	if err != nil {

--- a/client/cmd/query.go
+++ b/client/cmd/query.go
@@ -166,7 +166,7 @@ func query(ctx context.Context, query string) {
 	lib.CheckFatalError(DisplayResults(ctx, data, numResults))
 }
 
-func DisplayResults(ctx context.Context, results []*data.HistoryEntry, numResults int) error {
+func DisplayResults(ctx context.Context, results []*data.HistoryEntry, numResults int) (err error) {
 	config := hctx.GetConf(ctx)
 	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
 
@@ -213,7 +213,7 @@ func stringArrayToAnyArray(arr []string) []any {
 	return ret
 }
 
-func displayBannerIfSet(ctx context.Context) error {
+func displayBannerIfSet(ctx context.Context) (err error) {
 	respBody, err := lib.GetBanner(ctx)
 	if lib.IsOfflineError(ctx, err) {
 		return nil

--- a/client/cmd/redact.go
+++ b/client/cmd/redact.go
@@ -46,7 +46,7 @@ var redactCmd = &cobra.Command{
 	},
 }
 
-func redact(ctx context.Context, query string, skipUserConfirmation, skipOnlineRedaction bool) error {
+func redact(ctx context.Context, query string, skipUserConfirmation, skipOnlineRedaction bool) (err error) {
 	tx, err := lib.MakeWhereQueryFromSearch(ctx, hctx.GetDb(ctx), query)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func redact(ctx context.Context, query string, skipUserConfirmation, skipOnlineR
 	return nil
 }
 
-func deleteOnRemoteInstances(ctx context.Context, historyEntries []*data.HistoryEntry) error {
+func deleteOnRemoteInstances(ctx context.Context, historyEntries []*data.HistoryEntry) (err error) {
 	config := hctx.GetConf(ctx)
 	if config.IsOffline {
 		return nil

--- a/client/cmd/syncing.go
+++ b/client/cmd/syncing.go
@@ -47,10 +47,10 @@ var syncingCmd = &cobra.Command{
 	},
 }
 
-func switchToOnline(ctx context.Context) error {
+func switchToOnline(ctx context.Context) (err error) {
 	config := hctx.GetConf(ctx)
 	config.IsOffline = false
-	err := hctx.SetConfig(config)
+	err = hctx.SetConfig(config)
 	if err != nil {
 		return fmt.Errorf("failed to switch device to online due to error while setting config: %w", err)
 	}
@@ -65,10 +65,10 @@ func switchToOnline(ctx context.Context) error {
 	return nil
 }
 
-func switchToOffline(ctx context.Context) error {
+func switchToOffline(ctx context.Context) (err error) {
 	config := hctx.GetConf(ctx)
 	config.IsOffline = true
-	err := hctx.SetConfig(config)
+	err = hctx.SetConfig(config)
 	if err != nil {
 		return fmt.Errorf("failed to switch device to offline due to error while setting config: %w", err)
 	}

--- a/client/posttest/main.go
+++ b/client/posttest/main.go
@@ -142,7 +142,7 @@ func exportMetrics() {
 
 type eventHandler struct{}
 
-func (eventHandler) Event(event testjson.TestEvent, execution *testjson.Execution) error {
+func (eventHandler) Event(event testjson.TestEvent, execution *testjson.Execution) (err error) {
 	testIdentifier := event.Test
 	if event.Action == testjson.ActionFail {
 		fmt.Println("Recorded failure for " + testIdentifier)
@@ -157,6 +157,6 @@ func (eventHandler) Event(event testjson.TestEvent, execution *testjson.Executio
 	return nil
 }
 
-func (eventHandler) Err(text string) error {
+func (eventHandler) Err(text string) (err error) {
 	return fmt.Errorf("unexpected error when parsing test output: %v", text)
 }

--- a/client/testutils.go
+++ b/client/testutils.go
@@ -42,23 +42,23 @@ func (b bashTester) RunInteractiveShell(t testing.TB, script string) string {
 	return out
 }
 
-func (b bashTester) RunInteractiveShellRelaxed(t testing.TB, script string) (string, error) {
+func (b bashTester) RunInteractiveShellRelaxed(t testing.TB, script string) (outStr string, err error) {
 	cmd := exec.Command("bash", "-i")
 	cmd.Stdin = strings.NewReader(script)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		return "", fmt.Errorf("unexpected error when running commands, out=%#v, err=%#v: %w", stdout.String(), stderr.String(), err)
 	}
-	outStr := stdout.String()
+	outStr = stdout.String()
 	require.NotContains(t, outStr, "hishtory fatal error", "Ran command, but hishtory had a fatal error!")
 	return outStr, nil
 }
 
-func (b bashTester) RunInteractiveShellBackground(t testing.TB, script string) error {
+func (b bashTester) RunInteractiveShellBackground(t testing.TB, script string) (err error) {
 	cmd := exec.Command("bash", "-i")
 	// SetSid: true is required to prevent SIGTTIN signal killing the entire test
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
@@ -74,29 +74,29 @@ func (b bashTester) ShellName() string {
 
 type zshTester struct{}
 
-func (z zshTester) RunInteractiveShell(t testing.TB, script string) string {
+func (z zshTester) RunInteractiveShell(t testing.TB, script string) (res string) {
 	res, err := z.RunInteractiveShellRelaxed(t, "set -eo pipefail\n"+script)
 	require.NoError(t, err)
 	return res
 }
 
-func (z zshTester) RunInteractiveShellRelaxed(t testing.TB, script string) (string, error) {
+func (z zshTester) RunInteractiveShellRelaxed(t testing.TB, script string) (outStr string, err error) {
 	cmd := exec.Command("zsh", "-is")
 	cmd.Stdin = strings.NewReader(script)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		return stdout.String(), fmt.Errorf("unexpected error when running command=%#v, out=%#v, err=%#v: %w", script, stdout.String(), stderr.String(), err)
 	}
-	outStr := stdout.String()
+	outStr = stdout.String()
 	require.NotContains(t, outStr, "hishtory fatal error")
 	return outStr, nil
 }
 
-func (z zshTester) RunInteractiveShellBackground(t testing.TB, script string) error {
+func (z zshTester) RunInteractiveShellBackground(t testing.TB, script string) (err error) {
 	cmd := exec.Command("zsh", "-is")
 	cmd.Stdin = strings.NewReader(script)
 	cmd.Stdout = nil

--- a/client/webui/webui.go
+++ b/client/webui/webui.go
@@ -26,7 +26,7 @@ type webUiData struct {
 	ColumnNames   []string
 }
 
-func getTableRowsForDisplay(ctx context.Context, searchQuery string) ([][]string, error) {
+func getTableRowsForDisplay(ctx context.Context, searchQuery string) (rows [][]string, err error) {
 	results, err := lib.Search(ctx, hctx.GetDb(ctx), searchQuery, 100)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func getTemplates() *template.Template {
 	return template.Must(template.ParseFS(templateFiles, "templates/*"))
 }
 
-func buildTableRows(ctx context.Context, entries []*data.HistoryEntry) ([][]string, error) {
+func buildTableRows(ctx context.Context, entries []*data.HistoryEntry) (rows [][]string, err error) {
 	columnNames := hctx.GetConf(ctx).DisplayedColumns
 	ret := make([][]string, 0)
 	for _, entry := range entries {

--- a/shared/ai/ai.go
+++ b/shared/ai/ai.go
@@ -56,7 +56,7 @@ type TestOnlyOverrideAiSuggestionRequest struct {
 
 var TestOnlyOverrideAiSuggestions map[string][]string = make(map[string][]string)
 
-func GetAiSuggestionsViaOpenAiApi(apiEndpoint, query, shellName, osName, overriddenOpenAiModel string, numberCompletions int) ([]string, OpenAiUsage, error) {
+func GetAiSuggestionsViaOpenAiApi(apiEndpoint, query, shellName, osName, overriddenOpenAiModel string, numberCompletions int) (suggestions []string, usage OpenAiUsage, err error) {
 	if results := TestOnlyOverrideAiSuggestions[query]; len(results) > 0 {
 		return results, OpenAiUsage{}, nil
 	}

--- a/shared/data.go
+++ b/shared/data.go
@@ -85,14 +85,14 @@ type MessageIdentifier struct {
 	EntryId string `json:"entry_id"`
 }
 
-func (m *MessageIdentifiers) Scan(value any) error {
+func (m *MessageIdentifiers) Scan(value any) (err error) {
 	bytes, ok := value.([]byte)
 	if !ok {
 		return fmt.Errorf("failed to unmarshal JSONB value: %v", value)
 	}
 
 	result := MessageIdentifiers{}
-	err := json.Unmarshal(bytes, &result)
+	err = json.Unmarshal(bytes, &result)
 	*m = result
 	return err
 }

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -2,7 +2,7 @@ package shared
 
 import "sync"
 
-func ForEach[T any](arr []T, numThreads int, fn func(T) error) error {
+func ForEach[T any](arr []T, numThreads int, fn func(T) error) (err error) {
 	wg := &sync.WaitGroup{}
 	wg.Add(len(arr))
 


### PR DESCRIPTION
Its easier to manage err functions, when you always have the `err` variable instantiated in the named return.

Replaces this change with consistent change across the entire project. (*I will force push and remove it from the other commit*)
[#307](https://github.com/ddworken/hishtory/pull/307/files#r2008840182)