### PR TITLE
feat(tui): Add Regex search support with toggle (Ctrl+g)

### DIFF
--- a/client/tui/keybindings/keybindings.go
+++ b/client/tui/keybindings/keybindings.go
@@ -25,6 +25,7 @@ type SerializableKeyMap struct {
 	JumpEndOfInput          []string
 	WordLeft                []string
 	WordRight               []string
+	ToggleRegex             []string
 }
 
 func prettifyKeyBinding(kb string) string {
@@ -126,6 +127,10 @@ func (s SerializableKeyMap) ToKeyMap() KeyMap {
 			key.WithKeys(s.WordRight...),
 			key.WithHelp(prettifyKeyBinding(s.WordRight[0]), "jump right one word "),
 		),
+		ToggleRegex: key.NewBinding(
+			key.WithKeys(s.ToggleRegex...),
+			key.WithHelp(prettifyKeyBinding(s.ToggleRegex[0]), "toggle regex mode "),
+		),
 	}
 }
 
@@ -181,6 +186,9 @@ func (s SerializableKeyMap) WithDefaults() SerializableKeyMap {
 	if len(s.WordRight) == 0 {
 		s.WordRight = DefaultKeyMap.WordRight.Keys()
 	}
+	if len(s.ToggleRegex) == 0 {
+		s.ToggleRegex = DefaultKeyMap.ToggleRegex.Keys()
+	}
 	return s
 }
 
@@ -202,6 +210,7 @@ type KeyMap struct {
 	JumpEndOfInput          key.Binding
 	WordLeft                key.Binding
 	WordRight               key.Binding
+	ToggleRegex             key.Binding
 }
 
 func (k KeyMap) ToSerializable() SerializableKeyMap {
@@ -223,6 +232,7 @@ func (k KeyMap) ToSerializable() SerializableKeyMap {
 		JumpEndOfInput:          k.JumpEndOfInput.Keys(),
 		WordLeft:                k.WordLeft.Keys(),
 		WordRight:               k.WordRight.Keys(),
+		ToggleRegex:             k.ToggleRegex.Keys(),
 	}
 }
 
@@ -237,13 +247,13 @@ var fakeEmptyKeyBinding key.Binding = key.NewBinding(
 )
 
 func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{fakeTitleKeyBinding, k.Help}
+	return []key.Binding{fakeTitleKeyBinding, k.Help, k.ToggleRegex}
 }
 
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{fakeTitleKeyBinding, k.Up, k.Left, k.SelectEntry, k.SelectEntryAndChangeDir},
-		{fakeEmptyKeyBinding, k.Down, k.Right, k.DeleteEntry},
+		{fakeEmptyKeyBinding, k.Down, k.Right, k.DeleteEntry, k.ToggleRegex},
 		{fakeEmptyKeyBinding, k.PageUp, k.TableLeft, k.Quit},
 		{fakeEmptyKeyBinding, k.PageDown, k.TableRight, k.Help},
 	}
@@ -322,5 +332,9 @@ var DefaultKeyMap = KeyMap{
 	WordRight: key.NewBinding(
 		key.WithKeys("ctrl+right"),
 		key.WithHelp("ctrl+right", "jump right one word "),
+	),
+	ToggleRegex: key.NewBinding(
+		key.WithKeys("ctrl+g"),
+		key.WithHelp("ctrl+g", "toggle regex mode "),
 	),
 }

--- a/client/tui/tui.go
+++ b/client/tui/tui.go
@@ -207,7 +207,7 @@ func preventTableOverscrolling(m model) {
 }
 
 func runQueryAndUpdateTable(m model, forceUpdateTable, maintainCursor bool) tea.Cmd {
-	if (m.runQuery != nil && *m.runQuery != m.lastQuery) || forceUpdateTable || m.searchErr != nil || m.regexMode {
+	if (m.runQuery != nil && *m.runQuery != m.lastQuery) || forceUpdateTable || m.searchErr != nil {
 		query := m.lastQuery
 		if m.runQuery != nil {
 			query = *m.runQuery
@@ -281,7 +281,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.regexMode = !m.regexMode
 			searchQuery := m.queryInput.Value()
 			m.runQuery = &searchQuery
-			cmd := runQueryAndUpdateTable(m, false, true)
+			cmd := runQueryAndUpdateTable(m, true, true)
 			return m, cmd
 		case key.Matches(msg, loadedKeyBindings.JumpStartOfInput):
 			m.queryInput.SetCursor(0)


### PR DESCRIPTION
Closes #336

This PR introduces support for **Regex-based searching** in hishtory. It allows users to perform precise matching using regular expressions instead of the default fuzzy matching.

It also integrates this feature into the TUI with a new toggle mode.

- Added support for `regex:` and `re:` prefixes in search queries.
- Implemented `extractRegexPatterns` to correctly parse regex patterns from the query string, preserving escape characters (e.g., `\.sh$`).
- Implemented `filterByRegex` to filter history entries using Go's `regexp` package after fetching results from the database.
  - *Note: This approach avoids dependencies on SQLite CGO extensions for REGEXP support, ensuring compatibility.*

- **New Mode**: Added a `regexMode` state to the TUI model.
- **Visual Indicator**: When Regex mode is enabled, the prompt changes to `Search Query: [REGEX] >`.
- **Automatic Prefixing**: When in Regex mode, the user's input is automatically treated as a regex pattern (internally wrapped with `re:`).
- **Keybinding**: Added `Ctrl+g` (default) to toggle Regex mode on/off.
- **Help Menu**: Updated both `ShortHelp` (footer) and `FullHelp` (Ctrl+h) to display the new keybinding.
- **Layout**: Adjusted the `FullHelp` layout to include `ToggleRegex` in the second column for better visibility.

1. Rebuild and install: `go build . && ./hishtory install`
2. Open the TUI via `Ctrl+r`.
3. Press `Ctrl+g`. You should see the `[REGEX]` indicator appear.
4. Try regex queries:
   - `^git` (Commands starting with git)
   - `\.sh$` (Commands ending with .sh)
   - `docker.*run`
5. Press `Ctrl+h` to verify the keybinding `ctrl+g` is listed in the help menu.

- [x] Logic for regex filtering
- [x] TUI toggle implementation
- [x] Keybinding configuration (`Ctrl+g`)
- [x] Help menu updates